### PR TITLE
[Feat] 이메일인증 api 생성 (#70)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ dependencies {
 
     // oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework:spring-context-support'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/codeplay/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/umc/codeplay/apiPayLoad/code/status/ErrorStatus.java
@@ -33,7 +33,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     MUSIC_NOT_FOUND(HttpStatus.BAD_REQUEST, "MUSIC400", "음원을 찾을 수 없습니다."),
 
-    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "LIKE400", "해당 좋아요를 찾을 수 없습니다.");
+    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "LIKE400", "해당 좋아요를 찾을 수 없습니다."),
+
+    EMAIL_SEND_ERROR(HttpStatus.BAD_REQUEST, "EMAIL400", "메일 발송에 실패하였습니다."),
+    EMAIL_CODE_ERROR(HttpStatus.BAD_REQUEST, "EMAIL401", "유효한 코드가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/codeplay/dto/EmailCodeDTO.java
+++ b/src/main/java/umc/codeplay/dto/EmailCodeDTO.java
@@ -1,0 +1,18 @@
+package umc.codeplay.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EmailCodeDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VerificationCode {
+        String code;
+        LocalDateTime expires;
+    }
+}

--- a/src/main/java/umc/codeplay/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/codeplay/dto/MemberRequestDTO.java
@@ -31,4 +31,16 @@ public class MemberRequestDTO {
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
         String password;
     }
+
+    @Getter
+    public static class ResetPasswordDTO {
+        @Email(message = "이메일 형식이 아닙니다.")
+        String email;
+    }
+
+    @Getter
+    public static class CheckVerificationCodeDTO {
+        String email;
+        String code;
+    }
 }

--- a/src/main/java/umc/codeplay/service/EmailService.java
+++ b/src/main/java/umc/codeplay/service/EmailService.java
@@ -1,0 +1,88 @@
+package umc.codeplay.service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import umc.codeplay.apiPayLoad.code.status.ErrorStatus;
+import umc.codeplay.apiPayLoad.exception.GeneralException;
+import umc.codeplay.domain.Member;
+import umc.codeplay.dto.EmailCodeDTO;
+import umc.codeplay.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final MemberRepository memberRepository;
+    // application.yml에 발신 메일 설정 필요
+    private final JavaMailSender mailSender;
+
+    // 인증번호 저장
+    private final Map<String, EmailCodeDTO.VerificationCode> verificationCodes =
+            new ConcurrentHashMap<>();
+
+    // 비밀번호 찾기 인증번호 메일 보내기
+    public void sendCode(String email) throws MessagingException {
+        Member member =
+                memberRepository
+                        .findByEmail(email)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 인증번호 생성(5자리)
+        Random random = new Random();
+        final String code = String.format("%05d", random.nextInt(100000));
+
+        // 인증번호 저장 및 만료시간 설정
+        EmailCodeDTO.VerificationCode verificationCode =
+                new EmailCodeDTO.VerificationCode(code, LocalDateTime.now().plusMinutes(5));
+        verificationCodes.put(email, verificationCode);
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            String text =
+                    "<html>"
+                            + "<body>"
+                            + "<h2>안녕하세요, CodePlay입니다.</h2>"
+                            + "<p>비밀번호 재설정 코드입니다.</p>"
+                            + "<p><strong>인증번호: "
+                            + code
+                            + "</strong></p>"
+                            + "<p>이 코드는 5분간 유효합니다.</p>"
+                            + "<p>CodePlay 팀 드림</p>"
+                            + "</body>"
+                            + "</html>";
+
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setTo(email); // 수신자 이메일
+            helper.setSubject("CodePlay 비밀번호 재설정 코드"); // 이메일 제목
+            helper.setText(text, true); // HTML 본문을 true로 설정
+
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new GeneralException(ErrorStatus.EMAIL_SEND_ERROR);
+        }
+    }
+
+    // 코드 검증
+    public boolean verifyCode(String email, String code) {
+        EmailCodeDTO.VerificationCode verificationCode = verificationCodes.get(email);
+        if (verificationCode == null) {
+            return false;
+        }
+        if (verificationCode.getExpires().isBefore(LocalDateTime.now())) {
+            verificationCodes.remove(email); // 만료 코드 삭제
+            return false;
+        }
+        return verificationCode.getCode().equals(code);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,4 @@ kakao:
     token-uri: "https://kauth.kakao.com/oauth/token"
     user-info-uri: "https://kapi.kakao.com/v2/user/me"
     additional-parameters: ""
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   application:
     name: codeplay
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: dummy-email@gmail.com  # 이메일 계정
+    password: dummy-password
+    protocol: smt
+    tls: true
+
 
   config:
     import:


### PR DESCRIPTION
## PR 타입
> 하나 이상의 PR 타입을 선택해주세요.
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 관련
- [ ] 기타


## ⭐Related Issues
- closes #70


## 변경 사항
> 이메일 인증, 검증 로직 추가했습니다. 검증 이후에 비밀번호 변경 api 완성되면 연결 해야합니다.


## 테스트 결과
> 병합되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린 샷, GIF, 혹은 라이브 데모가 가능하도록 샘플 API를 추가할 수 있습니다.


## Must do
- [x] checked assignees
- [x] checked labels